### PR TITLE
Check untracked files before cross-commit

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,7 +33,7 @@ echo "running 'rsync -avh --delete "${EXCLUDES[@]}" $GITHUB_WORKSPACE/$SOURCE/ $
 rsync -avh --delete "${EXCLUDES[@]}" $GITHUB_WORKSPACE/$SOURCE/ $TEMP/$TARGET
 
 # Success finish early if there are no changes
-if git diff --no-ext-diff --quiet; then
+if [ -z "$(git status --porcelain)" ]; then
   echo "no changes to sync"
   exit 0
 fi


### PR DESCRIPTION
In https://github.com/drud/action-cross-commit/pull/1 I failed to check for untracked files. This meant if rsync created new files and didn't touch any of the old files, script would exit without creating commit in state repo.

Discovered this with https://github.com/drud/github-operator/pull/47
Shows in action run: https://github.com/drud/github-operator/commit/8c871af6122d4a837d19433b4628254b19c63851/checks?check_suite_id=391914172