### PR TITLE
Allow single file sync

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,8 +29,12 @@ cd $TEMP
 git checkout $BRANCH
 
 # Sync $TARGET folder to $REPO state repository with excludes
-echo "running 'rsync -avh --delete "${EXCLUDES[@]}" $GITHUB_WORKSPACE/$SOURCE/ $TEMP/$TARGET'"
-rsync -avh --delete "${EXCLUDES[@]}" $GITHUB_WORKSPACE/$SOURCE/ $TEMP/$TARGET
+f="/"
+if [[ -f "${GITHUB_WORKSPACE}/${SOURCE}" ]]; then
+    f=""
+then
+echo "running 'rsync -avh --delete "${EXCLUDES[@]}" $GITHUB_WORKSPACE/${SOURCE}${f} $TEMP/$TARGET'"
+rsync -avh --delete "${EXCLUDES[@]}" $GITHUB_WORKSPACE/${SOURCE}${f} $TEMP/$TARGET
 
 # Success finish early if there are no changes
 if [ -z "$(git status --porcelain)" ]; then


### PR DESCRIPTION
We would like to enable single files to be synced as well, currently this fails because the script appends `/` to the end of the source path.

```
running 'rsync -avh --delete  /github/workspace/ddev-api-0.1.1.tgz/ /tmp/tmp.AncicM/charts'
rsync: change_dir "/github/workspace/ddev-api-0.1.1.tgz" failed: Not a directory (20)
```

Because we are using this as is already, we can't just remove the `/` because that would cause a regression, these two behave differently
```bash
$ ls /source/folder
a

$ rsync -avh /source/folder  /dest  # results in /dest/folder/a
$ rsync -avh /source/folder/ /dest  # results in /dest/a
```
the first rsync command would result in `/dest/folder/a`, while second rsync command syncs directly the content of `folder` to `/dest` and results in `/dest/a` which is what we are currently using.