### PR TITLE
Add 'git-commit-message' input variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ steps:
     destination-repository: https://<user>:${{ secrets.user_token }}@github.com/org/dest-repo
     destination-folder: .
     destination-branch: alpha
-    git-user: "Git User" 
+    git-user: "Git User"
     git-user-email: git-user@email.com
+    git-commit-message: "Custom commit message (optional)"
     excludes: README.md:.git:path/deeper/in/the/repo
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,10 @@ inputs:
   git-user-email:
     description: "User email that will be used to create the git commit"
     required: true
+  git-commit-message:
+    description: "Custom commit message to use"
+    default: ""
+    required: false
   excludes:
     description: "Optionally exclude some directories from being synced in both src and dst. The value is treated as column separated list, e.g. skip_dir_in_src:.git:skip_dir_in_dst"
 runs:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,9 +9,10 @@ TARGET="$3"
 BRANCH="$4"
 GIT_USER="$5"
 GIT_EMAIL="$6"
+GIT_COMMIT_MSG="$7"
 EXCLUDES=()
-if [[ ! -z ${7+x} ]]; then
-    X=(${7//:/ })
+if [[ ! -z ${8+x} ]]; then
+    X=(${8//:/ })
     for x in "${X[@]}"; do
         EXCLUDES+=('--exclude')
         EXCLUDES+=("/$x")
@@ -54,12 +55,18 @@ fi
 
 # Add changes and push commit
 git add .
-SHORT_SHA=$(echo $GITHUB_SHA | head -c 6)
-git commit -F- <<EOF
+
+if [[ -n "$GIT_COMMIT_MSG" ]]; then
+  git commit -m "$GIT_COMMIT_MSG"
+else
+  SHORT_SHA=$(echo $GITHUB_SHA | head -c 6)
+  git commit -F- <<EOF
 Automatic CI SYNC Commit $SHORT_SHA
 
 Syncing with $GITHUB_REPOSITORY commit $GITHUB_SHA
 EOF
+fi
+
 if [[ -n "$LS_REMOTE" ]]; then
   git push
 else


### PR DESCRIPTION
This variable is empty and optional, if it's
provided it will be used otherwise it will fall
back to the default generated commit message.