### PR TITLE
Add ability to sign-off on a commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ steps:
     git-user: "Git User"
     git-user-email: git-user@email.com
     git-commit-message: "Custom commit message (optional)"
+    git-commit-sign-off: "false"
     excludes: README.md:.git:path/deeper/in/the/repo
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "Custom commit message to use"
     default: ""
     required: false
+  git-commit-sign-off:
+    description: "Sign-off commit"
+    default: "false"
+    required: false
   excludes:
     description: "Optionally exclude some directories from being synced in both src and dst. The value is treated as column separated list, e.g. skip_dir_in_src:.git:skip_dir_in_dst"
     required: false
@@ -38,4 +42,5 @@ runs:
     - ${{ inputs.git-user }}
     - ${{ inputs.git-user-email }}
     - ${{ inputs.git-commit-message }}
+    - ${{ inputs.git-commit-sign-off }}
     - ${{ inputs.excludes }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,10 +10,11 @@ BRANCH="$4"
 GIT_USER="$5"
 GIT_EMAIL="$6"
 GIT_COMMIT_MSG="$7"
+GIT_COMMIT_SIGN_OFF="$8"
 EXCLUDES=()
 
-if [[ -n ${8+x} ]]; then
-    X=("${8//:/ }")
+if [[ -n ${9+x} ]]; then
+    X=("${9//:/ }")
     for x in ${X[*]}; do
         EXCLUDES+=('--exclude')
         EXCLUDES+=("/$x")
@@ -57,11 +58,16 @@ fi
 # Add changes and push commit
 git add .
 
+commit_signoff=""
+if [ "${GIT_COMMIT_SIGN_OFF}" = "true" ]; then
+  commit_signoff="-s"
+fi
+
 if [[ -n "$GIT_COMMIT_MSG" ]]; then
-  git commit -m "$GIT_COMMIT_MSG"
+  git commit ${commit_signoff} -m "$GIT_COMMIT_MSG"
 else
   SHORT_SHA=$(echo "$GITHUB_SHA" | head -c 6)
-  git commit -F- <<EOF
+  git commit ${commit_signoff} -F- <<EOF
 Automatic CI SYNC Commit $SHORT_SHA
 
 Syncing with $GITHUB_REPOSITORY commit $GITHUB_SHA


### PR DESCRIPTION
Add `git-commit-sign-off` (default to `false`) property to be able to sign-off on a commit.

Note: this has a soft dependency on #10, but I'll be able to rebase one over another, and eventually it won't matter which one gets merged first.