### PR TITLE
Fix lint and yaml warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Cross Commit
 
-Github action that allows synchronizing parts of repositories. It runs rsync 
-between source folder in current repository to destination repository and 
+Github action that allows synchronizing parts of repositories. It runs rsync
+between source folder in current repository to destination repository and
 destination folder and creates a commit in destination repository. Typical
 usage is for synchronizing to GitOps state repositories from source code.
 
-# Usage
+## Usage
 
 See [action.yml](action.yml)
 
@@ -26,13 +26,13 @@ steps:
     excludes: README.md:.git:path/deeper/in/the/repo
 ```
 
-The example above will trigger `rsync` that will synchronize the files in 
+The example above will trigger `rsync` that will synchronize the files in
 `./config` to repository `github.com/org/dest-repo` root using user credentials
-(can be stored as Github secrets) and create commit on `alpha` branch. The 
-`rsync` will exclude `/.git`, `/README.md` and `/path/deeper/in/the/repo` from 
+(can be stored as Github secrets) and create commit on `alpha` branch. The
+`rsync` will exclude `/.git`, `/README.md` and `/path/deeper/in/the/repo` from
 both repositories during the synchronization.
 
-# License
+## License
 
-This project is licensed under Apache 2.0 license. Read the [LICENSE](LICENSE) 
+This project is licensed under Apache 2.0 license. Read the [LICENSE](LICENSE)
 file in the top distribution directory, for the full license text.

--- a/action.yml
+++ b/action.yml
@@ -26,6 +26,7 @@ inputs:
     required: false
   excludes:
     description: "Optionally exclude some directories from being synced in both src and dst. The value is treated as column separated list, e.g. skip_dir_in_src:.git:skip_dir_in_dst"
+    required: false
 runs:
   using: "docker"
   image: "Dockerfile"


### PR DESCRIPTION
This PR fixes:

- lint warnings in `README.md` (mostly remove trailing space)
- yaml warning in `action.yml` (add missing field)